### PR TITLE
Catch interpreter and std exceptions

### DIFF
--- a/src/xcpp_interpreter.hpp
+++ b/src/xcpp_interpreter.hpp
@@ -52,8 +52,6 @@ namespace xeus
 
         void input_reply_impl(const std::string& value) override;
 
-        void expose(const std::string& type, void* obj, const std::string& name);
-
         xjson get_error_reply(const std::string& ename,
                               const std::string& evalue,
                               const std::vector<std::string>& trace_back);


### PR DESCRIPTION
Exceptions raised by the interpreted code propagate to the interpreter and must be caught.

Besides, I removed the `pre` tag of the inspect pager, and exposed the interpreter instance to the cling context in a more robust fashion.