### PR TITLE
interpreter exposed to cling

### DIFF
--- a/src/xcpp_interpreter.cpp
+++ b/src/xcpp_interpreter.cpp
@@ -27,18 +27,16 @@ namespace xeus
         // Process #include "xeus/xinterpreter.hpp" in a separate block.
         cling::Value result;
         cling::Interpreter::CompilationResult compilation_result;
-        m_processor.process("#include \"xeus/xinterpreter.hpp\"", compilation_result, &result);
+        m_processor.process("#include \"xwidgets/xwidgets_interpreter.hpp\"", compilation_result, &result);
 
         // Expose interpreter instance to cling
         std::string
-        block  = "namespace xeus                                                                                                ";
-        block += "{                                                                                                             ";
-        block += "    xinterpreter& get_interpreter()                                                                           ";
-        block += "    {                                                                                                         ";
-        block += "        static auto& interpreter = *static_cast<xinterpreter*>((void*)" + std::to_string(intptr_t(this)) + ");";
-        block += "        return interpreter;                                                                                   ";
-        block += "    }                                                                                                         ";
-        block += "}                                                                                                             ";
+        block  = "namespace"                                                                       ;
+        block += "{"                                                                               ;
+        block += "    bool registered = ::xeus::register_interpreter("                             ;
+        block += "      static_cast<xinterpreter*>((void*)" + std::to_string(intptr_t(this)) + ");";
+        block += "    );"                                                                          ;
+        block += "}"                                                                               ;
         m_processor.process(block.c_str(), compilation_result, &result);
     }
 


### PR DESCRIPTION
@SylvainCorlay @gouarin 

I've slightly changed the way we expose the interpreter to cling, it is now registered into a variable in the widgets (that requires the master branch of the widgets); that might not be ideal but that is the easiest solution that allows to have the widgets both in xeus-cling and in a standalone mode.

I will change this later since we may need the interpreter for other purpose than the widgets, and the widgets may not be installed.

EDIT: possible solution: scanning the potentially installed extensions / libraries, and called a `register_interpreter` method for each of them. This requires some pattern in the header names.