### PR TITLE
Specify that this is miniconda3 only for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project is in development phase and is highly instable!
 
 ## Installation
 
-xeus-cling has been packaged for the conda package manager on the linux platform. From a new miniconda install:
+xeus-cling has been packaged for the conda package manager on the linux platform. From a new miniconda3 install:
 
 ```
 conda install cling -c QuantStack -c conda-forge


### PR DESCRIPTION
QuantStack does not provide a cling package for miniconda2 for now, and conda-forge's cling has a libc issue.