### PR TITLE
Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,13 +81,14 @@ set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
 if(MSVC)
     add_definitions(/DNOMINMAX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4251 /wd4141")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4018 /wd4267 /wd4715 /wd4146 /wd4129")
 endif()
 
 ###################
 # Target and link #
 ###################
 
-
+include(GNUInstallDirs)
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
@@ -102,6 +103,7 @@ set(XEUSCLING_SRC
     src/xbuffer.hpp
     src/xcpp_interpreter.cpp
     src/xcpp_interpreter.hpp
+    src/xdemangle.hpp
     src/xoptions.cpp
     src/xoptions.hpp
     src/xparser.cpp
@@ -112,18 +114,22 @@ set(XEUSCLING_SRC
     src/xmagics/os.cpp
     src/xmagics/os.hpp
 )
-
+set(LLVM_NO_DEAD_STRIP 1)
+#set(LIBS ${xeus_LIBRARY} LLVMSupport clangFrontendTool clingUserInterface clingInterpreter clingMetaProcessor clingUtils pugixml)
 set(LIBS ${xeus_LIBRARY} clingInterpreter clingMetaProcessor clingUtils pugixml)
 set(XEUSCLING_TARGET xeus-cling)
 add_executable(${XEUSCLING_TARGET} ${XEUSCLING_SRC})
 set_target_properties(${XEUSCLING_TARGET} PROPERTIES ENABLE_EXPORTS 1)
+
+if(MSVC)
+  set_target_properties(${XEUSCLING_TARGET} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)  # Internal string
+endif(MSVC)
+
 target_link_libraries(${XEUSCLING_TARGET} ${LIBS})
 
 ################
 # Installation #
 ################
-
-include(GNUInstallDirs)
 
 install(TARGETS ${XEUSCLING_TARGET}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/xdemangle.hpp
+++ b/src/xdemangle.hpp
@@ -1,0 +1,64 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Loic Gouarin and Sylvain Corlay       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+#ifndef XDEMANGLE_HPP
+#define XDEMANGLE_HPP
+
+// __has_include is currently supported by GCC and Clang. However GCC 4.9 may have issues and
+// returns 1 for 'defined( __has_include )', while '__has_include' is actually not supported:
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63662
+#if defined(__has_include) && (!defined(__GNUC__) || (__GNUC__ + 0) >= 5)
+    #if __has_include(<cxxabi.h>)
+        #define XEUS_HAS_CXXABI_H
+    #endif
+#elif defined(__GLIBCXX__) || defined(__GLIBCPP__)
+    #define XEUS_HAS_CXXABI_H
+#endif
+
+#if defined(XEUS_HAS_CXXABI_H)
+    #include <cxxabi.h>
+    // For some archtectures (mips, mips64, x86, x86_64) cxxabi.h in Android NDK is implemented by gabi++ library
+    // (https://android.googlesource.com/platform/ndk/+/master/sources/cxx-stl/gabi++/), which does not implement
+    // abi::__cxa_demangle(). We detect this implementation by checking the include guard here.
+    #if defined(_GABIXX_CXXABI_H__)
+        #undef XEUS_HAS_CXXABI_H
+    #else
+        #include <cstdlib>
+    #endif
+#endif
+
+namespace xeus
+{
+    const char* demangle(const char* name) noexcept;
+    const char* demangle(const std::string& name) noexcept;
+
+#if defined(XEUS_HAS_CXX_ABI_H)
+
+    inline const char* demangle(const char* name) noexcept
+    {
+        std::size_t size = 0;
+        std::size_t status = 0;
+        return abi::____cxa_demangle(name, 0, &size, &status);
+    }
+#else
+
+    inline const char* demangle(const char* name) noexcept
+    {
+        return name;
+    }
+
+#endif
+
+    inline const char* demangle(const std::string& name) noexcept
+    {
+        return demangle(name.c_str());
+    }
+
+}
+
+#endif
+

--- a/src/xinspect.hpp
+++ b/src/xinspect.hpp
@@ -8,15 +8,14 @@
 #ifndef XINSPECT_HPP
 #define XINSPECT_HPP
 
-#include <cxxabi.h>
 #include <fstream>
 #include <pugixml.hpp>
 #include <string>
-
 #include "cling/Interpreter/Interpreter.h"
 #include "cling/Interpreter/Value.h"
 #include "cling/Utils/Output.h"
 
+#include "xdemangle.hpp"
 #include "xparser.hpp"
 
 namespace xeus
@@ -110,11 +109,10 @@ namespace xeus
             std::regex re_typename("\\\"(.*)\\\"");
             std::smatch typename_;
             std::regex_search(valueString, typename_, re_typename);
-            int status;
             // set in valueString the typename given by typeid
             valueString = typename_.str(1);
             // we need demangling in order to have its string representation
-            valueString = abi::__cxa_demangle(valueString.c_str(), 0, 0, &status);
+            valueString = demangle(valueString);
             
             re_typename = "(\\w*(?:\\:{2}?\\w*)*)";
             std::regex_search(valueString, typename_, re_typename);

--- a/src/xparser.cpp
+++ b/src/xparser.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <iostream>
 #include <regex>
+#include <sstream>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This PR adds a wrapper around the demangler that fallbacks on an empty implementation on Windows.
The changes in the CMakeLists are required but not sufficient to have a correct build on Windows.