### PR TITLE
Some formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# xeus-cling
+# ![xeus-cling](http://quantstack.net/assets/images/xeus-cling.svg)
+
+[![Join the Gitter Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/QuantStack/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 `xeus-cling` is a Jupyter kernel for C++ based on the C++ interpreter [cling](https://github.com/root-project/cling) and
 the native implementation of the Jupyter protocol [xeus](https://github.com/QuantStack/xeus).
@@ -38,3 +40,10 @@ Launch the jupyter notebook with `jupyter notebook` and launch a new C++ noteboo
 
 The `QuantStack` channel provides a `xeus`, `cling` and their dependencies built with gcc-6. We highly recommend installing
 these dependencies from QuantStack in a clean conda installation or environment.
+
+## License
+
+We use a shared copyright model that enables all contributors to maintain the
+copyright on their contributions.
+
+This software is licensed under the BSD-3-Clause license. See the [LICENSE](LICENSE) file for details.

--- a/kernels/xeus-cling-cpp17/kernel.json
+++ b/kernels/xeus-cling-cpp17/kernel.json
@@ -1,9 +1,0 @@
-{
-  "display_name": "xeus C++17",
-  "argv": [
-      "xeus-cling",
-      "-f",
-      "{connection_file}",
-      "-std=c++17"
-  ]
-}

--- a/src/xbuffer.hpp
+++ b/src/xbuffer.hpp
@@ -1,10 +1,18 @@
-#ifndef XMESSAGING_BUFFER_HPP
-#define XMESSAGING_BUFFER_HPP
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Loic Gouarin and Sylvain Corlay       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
 
-#include <streambuf>
+#ifndef XCPP_MESSAGING_BUFFER_HPP
+#define XCPP_MESSAGING_BUFFER_HPP
+
 #include <functional>
-#include <string>
 #include <memory>
+#include <streambuf>
+#include <string>
 
 namespace xeus
 {
@@ -14,8 +22,9 @@ namespace xeus
     public:
 
         using callback_type = std::function<void(std::string)>;
-   
-        xbuffer(callback_type callback) : m_callback(std::move(callback))
+
+        xbuffer(callback_type callback)
+            : m_callback(std::move(callback))
         {
             this->setp(this->m_buffer, this->m_buffer + sizeof(this->m_buffer) - 1);
         }
@@ -30,9 +39,9 @@ namespace xeus
                 *this->pptr() = traits_type::to_char_type(c);
                 this->pbump(1);
             }
-            return this->sync() ? traits_type::not_eof(c): traits_type::eof();
+            return this->sync() ? traits_type::not_eof(c) : traits_type::eof();
         }
-    
+
         int sync() override
         {
             if (this->pbase() != this->pptr())
@@ -42,7 +51,7 @@ namespace xeus
             }
             return 0;
         }
-    
+
         callback_type m_callback;
         char m_buffer[1024];
     };

--- a/src/xcpp_interpreter.cpp
+++ b/src/xcpp_interpreter.cpp
@@ -7,22 +7,22 @@
 ****************************************************************************/
 
 #include <algorithm>
+#include <memory>
 #include <regex>
 #include <sstream>
 #include <vector>
-#include <memory>
 
-#include "cling/Interpreter/Value.h"
 #include "cling/Interpreter/Exception.h"
+#include "cling/Interpreter/Value.h"
 #include "cling/Utils/Output.h"
 
+#include "xbuffer.hpp"
 #include "xcpp_interpreter.hpp"
 #include "xinspect.hpp"
-#include "xparser.hpp"
-#include "xbuffer.hpp"
 #include "xmagics.hpp"
-#include "xmagics/os.hpp"
 #include "xmagics/execution.hpp"
+#include "xmagics/os.hpp"
+#include "xparser.hpp"
 #include "xsystem.hpp"
 
 using namespace std::placeholders;
@@ -45,7 +45,7 @@ namespace xeus
     xcpp_interpreter::xcpp_interpreter(int argc, const char* const* argv)
         : m_cling(argc, argv, LLVM_DIR), m_processor(m_cling, cling::errs()),
           p_cout_strbuf(nullptr), p_cerr_strbuf(nullptr),
-          m_cout_buffer(std::bind(&xcpp_interpreter::publish_stdout, this, _1)), 
+          m_cout_buffer(std::bind(&xcpp_interpreter::publish_stdout, this, _1)),
           m_cerr_buffer(std::bind(&xcpp_interpreter::publish_stderr, this, _1)),
           xmagics()
     {
@@ -70,7 +70,7 @@ namespace xeus
         cling::Interpreter::CompilationResult compilation_result;
         xjson kernel_res;
 
-        for(auto& pre: preamble_manager.preamble)
+        for (auto& pre : preamble_manager.preamble)
         {
             if (pre.second.is_match(code))
             {
@@ -94,13 +94,13 @@ namespace xeus
                 if (!e.diagnose())
                 {
                     std::cerr << "Caught an interpreter exception!\n"
-                            << e.what() << '\n';
+                              << e.what() << '\n';
                 }
             }
             catch (std::exception& e)
             {
                 std::cerr << "Caught a std::exception!\n"
-                            << e.what() << '\n';
+                          << e.what() << '\n';
             }
             catch (...)
             {
@@ -169,7 +169,7 @@ namespace xeus
 
         auto dummy = code.substr(0, cursor_pos);
         // FIX: same pattern as in inspect function (keep only one)
-        std::string exp = R"(\w*(?:\:{2}|\<.*\>|\(.*\)|\[.*\])?)" ;
+        std::string exp = R"(\w*(?:\:{2}|\<.*\>|\(.*\)|\[.*\])?)";
         std::regex re_method{"(" + exp + R"(\.?)*$)"};
         std::smatch magic;
         if (std::regex_search(dummy, magic, re_method))

--- a/src/xcpp_interpreter.hpp
+++ b/src/xcpp_interpreter.hpp
@@ -13,8 +13,9 @@
 #include "cling/MetaProcessor/MetaProcessor.h"
 
 #include "xeus/xinterpreter.hpp"
-#include "xmanager.hpp"
+
 #include "xbuffer.hpp"
+#include "xmanager.hpp"
 
 #include <iostream>
 #include <sstream>

--- a/src/xdemangle.hpp
+++ b/src/xdemangle.hpp
@@ -5,30 +5,31 @@
 *                                                                          *
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
-#ifndef XDEMANGLE_HPP
-#define XDEMANGLE_HPP
+
+#ifndef XCPP_DEMANGLE_HPP
+#define XCPP_DEMANGLE_HPP
 
 // __has_include is currently supported by GCC and Clang. However GCC 4.9 may have issues and
 // returns 1 for 'defined( __has_include )', while '__has_include' is actually not supported:
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63662
 #if defined(__has_include) && (!defined(__GNUC__) || (__GNUC__ + 0) >= 5)
-    #if __has_include(<cxxabi.h>)
-        #define XEUS_HAS_CXXABI_H
-    #endif
+#if __has_include(<cxxabi.h>)
+#define XEUS_HAS_CXXABI_H
+#endif
 #elif defined(__GLIBCXX__) || defined(__GLIBCPP__)
-    #define XEUS_HAS_CXXABI_H
+#define XEUS_HAS_CXXABI_H
 #endif
 
 #if defined(XEUS_HAS_CXXABI_H)
-    #include <cxxabi.h>
-    // For some archtectures (mips, mips64, x86, x86_64) cxxabi.h in Android NDK is implemented by gabi++ library
-    // (https://android.googlesource.com/platform/ndk/+/master/sources/cxx-stl/gabi++/), which does not implement
-    // abi::__cxa_demangle(). We detect this implementation by checking the include guard here.
-    #if defined(_GABIXX_CXXABI_H__)
-        #undef XEUS_HAS_CXXABI_H
-    #else
-        #include <cstdlib>
-    #endif
+#include <cxxabi.h>
+// For some archtectures (mips, mips64, x86, x86_64) cxxabi.h in Android NDK is implemented by gabi++ library
+// (https://android.googlesource.com/platform/ndk/+/master/sources/cxx-stl/gabi++/), which does not implement
+// abi::__cxa_demangle(). We detect this implementation by checking the include guard here.
+#if defined(_GABIXX_CXXABI_H__)
+#undef XEUS_HAS_CXXABI_H
+#else
+#include <cstdlib>
+#endif
 #endif
 
 namespace xeus
@@ -65,8 +66,6 @@ namespace xeus
     }
 
 #endif
-
 }
 
 #endif
-

--- a/src/xholder_cling.cpp
+++ b/src/xholder_cling.cpp
@@ -1,5 +1,5 @@
-#include "xpreamble.hpp"
 #include "xholder_cling.hpp"
+#include "xpreamble.hpp"
 
 #include <algorithm>
 
@@ -9,11 +9,13 @@ namespace xeus
     /***********************************
      * xholder_preamble implementation *
      ***********************************/
-    xholder_preamble::xholder_preamble() : p_holder(nullptr)
+    xholder_preamble::xholder_preamble()
+        : p_holder(nullptr)
     {
     }
 
-    xholder_preamble::xholder_preamble(xpreamble* holder) : p_holder(holder)
+    xholder_preamble::xholder_preamble(xpreamble* holder)
+        : p_holder(holder)
     {
     }
 
@@ -23,27 +25,28 @@ namespace xeus
     }
 
     xholder_preamble::xholder_preamble(const xholder_preamble& rhs)
-       : p_holder(rhs.p_holder ? rhs.p_holder->clone() : nullptr)
+        : p_holder(rhs.p_holder ? rhs.p_holder->clone() : nullptr)
     {
     }
 
-    xholder_preamble::xholder_preamble(xholder_preamble&& rhs) : p_holder(rhs.p_holder)
+    xholder_preamble::xholder_preamble(xholder_preamble&& rhs)
+        : p_holder(rhs.p_holder)
     {
         rhs.p_holder = nullptr;
     }
 
     xholder_preamble& xholder_preamble::operator=(const xholder_preamble& rhs)
     {
-       xholder_preamble tmp(rhs);
-       swap(tmp);
-       return *this;
+        xholder_preamble tmp(rhs);
+        swap(tmp);
+        return *this;
     }
 
     xholder_preamble& xholder_preamble::operator=(xholder_preamble&& rhs)
     {
-       xholder_preamble tmp(std::move(rhs));
-       swap(tmp);
-       return *this;
+        xholder_preamble tmp(std::move(rhs));
+        swap(tmp);
+        return *this;
     }
 
     xholder_preamble& xholder_preamble::operator=(xpreamble* holder)
@@ -54,19 +57,19 @@ namespace xeus
     }
 
 
-    void xholder_preamble::apply(const std::string& s, xjson& kernel_res) 
+    void xholder_preamble::apply(const std::string& s, xjson& kernel_res)
     {
         if (p_holder != nullptr)
         {
-            p_holder->apply(s, kernel_res) ;
+            p_holder->apply(s, kernel_res);
         }
     }
 
-    bool xholder_preamble::is_match(const std::string& s) const 
+    bool xholder_preamble::is_match(const std::string& s) const
     {
         if (p_holder != nullptr)
         {
-            return p_holder->is_match(s) ;
+            return p_holder->is_match(s);
         }
         return false;
     }

--- a/src/xholder_cling.hpp
+++ b/src/xholder_cling.hpp
@@ -5,8 +5,9 @@
 *                                                                          *
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
-#ifndef XHOLDER_CLING_HPP
-#define XHOLDER_CLING_HPP
+
+#ifndef XCPP_HOLDER_CLING_HPP
+#define XCPP_HOLDER_CLING_HPP
 
 #include "xeus/xjson.hpp"
 #include "xpreamble.hpp"
@@ -44,6 +45,6 @@ namespace xeus
     private:
 
         xpreamble* p_holder;
-    };    
+    };
 }
 #endif

--- a/src/xinspect.hpp
+++ b/src/xinspect.hpp
@@ -5,20 +5,22 @@
 *                                                                          *
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
-#ifndef XINSPECT_HPP
-#define XINSPECT_HPP
+
+#ifndef XCPP_INSPECT_HPP
+#define XCPP_INSPECT_HPP
 
 #include <fstream>
-#include <pugixml.hpp>
 #include <string>
 
-#include "cling/MetaProcessor/MetaProcessor.h"
+#include "pugixml.hpp"
+
 #include "cling/Interpreter/Interpreter.h"
 #include "cling/Interpreter/Value.h"
+#include "cling/MetaProcessor/MetaProcessor.h"
 #include "cling/Utils/Output.h"
 
-#include "xdemangle.hpp"
 #include "xbuffer.hpp"
+#include "xdemangle.hpp"
 #include "xparser.hpp"
 #include "xpreamble.hpp"
 
@@ -79,7 +81,7 @@ namespace xeus
         m_processor.process(code.c_str(), compilation_result, &result);
 
         // try to find the typename of the class
-        code = "typeid("+ expression + ").name();";
+        code = "typeid(" + expression + ").name();";
 
         // Temporarily dismissing all std::cerr and std::cout resulting from `m_processor.process`
         auto errorlevel = 0;
@@ -117,7 +119,7 @@ namespace xeus
             valueString = typename_.str(1);
             // we need demangling in order to have its string representation
             valueString = demangle(valueString);
-            
+
             re_typename = "(\\w*(?:\\:{2}?\\w*)*)";
             std::regex_search(valueString, typename_, re_typename);
             if (!typename_.str(1).empty())
@@ -157,7 +159,7 @@ namespace xeus
 
             if (!typename_.empty())
             {
-                while(search >> url >> tagfile)
+                while (search >> url >> tagfile)
                 {
                     std::string filename = tagfile_dir + "/" + tagfile;
                     pugi::xml_document doc;
@@ -174,22 +176,22 @@ namespace xeus
         else
         {
             std::string findString;
-            
+
             // check if we try to find the documentation of a namespace
             // if yes, don't try to find the type using typeid
             std::regex is_namespace(R"(\w+(\:{2}\w+)+)");
             std::smatch namespace_match;
-            if (std::regex_match(to_inspect, namespace_match, is_namespace)) 
+            if (std::regex_match(to_inspect, namespace_match, is_namespace))
             {
                 findString = to_inspect;
             }
             else
             {
                 std::string typename_ = find_type(to_inspect, m_processor);
-                findString = (typename_.empty())? to_inspect: typename_;
+                findString = (typename_.empty()) ? to_inspect : typename_;
             }
 
-            while(search >> url >> tagfile)
+            while (search >> url >> tagfile)
             {
                 std::string filename = tagfile_dir + "/" + tagfile;
                 pugi::xml_document doc;
@@ -210,7 +212,7 @@ namespace xeus
 
                     if (!node.empty())
                     {
-                       inspect_result = url + node;
+                        inspect_result = url + node;
                     }
                 }
             }
@@ -244,35 +246,33 @@ namespace xeus
                 border: none;
             }
             </style>
-            <iframe class="xeus-iframe-pager" src=")" + inspect_result + R"("></iframe>)";
+            <iframe class="xeus-iframe-pager" src=")" +
+                inspect_result + R"("></iframe>)";
 
             kernel_res["payload"] = {
-                xjson::object({
-                    {"data", {
-                        {"text/plain", inspect_result},
-                        {"text/html", html_content}}},
-                    {"source", "page"},
-                    {"start", 0}})
-            };
+                xjson::object({{"data", {{"text/plain", inspect_result}, {"text/html", html_content}}},
+                               {"source", "page"},
+                               {"start", 0}})};
 
             kernel_res["data"] =
                 xjson::object({{"text/plain", inspect_result},
-                               {"text/html", html_content}})
-            ;
+                               {"text/html", html_content}});
 
             std::cout << std::flush;
             kernel_res["found"] = true;
             kernel_res["status"] = "ok";
         }
-
     }
 
-    struct xintrospection: xpreamble
+    class xintrospection : xpreamble
     {
+    public:
+
         using xpreamble::pattern;
         const std::string spattern = R"(^\?)";
 
-        xintrospection(cling::MetaProcessor& p):m_processor{p}
+        xintrospection(cling::MetaProcessor& p)
+            : m_processor{p}
         {
             pattern = spattern;
         }
@@ -289,10 +289,10 @@ namespace xeus
         {
             return new xintrospection(*this);
         }
-        
-        private:
-            cling::MetaProcessor& m_processor;
-    };
 
+    private:
+
+        cling::MetaProcessor& m_processor;
+    };
 }
 #endif

--- a/src/xmagics.hpp
+++ b/src/xmagics.hpp
@@ -5,8 +5,9 @@
 *                                                                          *
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
-#ifndef XMAGICS_HPP
-#define XMAGICS_HPP
+
+#ifndef XCPP_MAGICS_HPP
+#define XCPP_MAGICS_HPP
 
 #include <map>
 #include <memory>
@@ -16,19 +17,23 @@
 
 namespace xeus
 {
-    enum struct xmagic_type{cell, line};
+    enum struct xmagic_type
+    {
+        cell,
+        line
+    };
 
     struct xmagic_line
     {
         virtual void operator()(const std::string& line) = 0;
     };
-    
+
     struct xmagic_cell
     {
         virtual void operator()(const std::string& line, const std::string& cell) = 0;
     };
 
-    struct xmagic_line_cell: public xmagic_line, xmagic_cell
+    struct xmagic_line_cell : public xmagic_line, xmagic_cell
     {
     };
 }

--- a/src/xmanager.hpp
+++ b/src/xmanager.hpp
@@ -5,12 +5,13 @@
 *                                                                          *
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
-#ifndef XMANAGER_HPP
-#define XMANAGER_HPP
 
-#include "xpreamble.hpp"
-#include "xmagics.hpp"
+#ifndef XCPP_MANAGER_HPP
+#define XCPP_MANAGER_HPP
+
 #include "xholder_cling.hpp"
+#include "xmagics.hpp"
+#include "xpreamble.hpp"
 
 namespace xeus
 {
@@ -18,7 +19,7 @@ namespace xeus
     {
         std::map<std::string, xholder_preamble> preamble;
 
-        template<typename preamble_type>
+        template <typename preamble_type>
         void register_preamble(const std::string& name, preamble_type* pre)
         {
             preamble[name] = xholder_preamble(pre);
@@ -35,9 +36,10 @@ namespace xeus
         }
     };
 
-    class xmagics_manager: public xpreamble
+    class xmagics_manager : public xpreamble
     {
     public:
+
         using xpreamble::pattern;
 
         xmagics_manager()
@@ -45,7 +47,7 @@ namespace xeus
             pattern = R"(^(?:\%{2}|\%)(\w+))";
         }
 
-        template<typename xmagic_type>
+        template <typename xmagic_type>
         void register_magic(const std::string& magic_name, xmagic_type magic)
         {
             auto shared = std::make_shared<xmagic_type>(magic);
@@ -67,9 +69,9 @@ namespace xeus
 
         bool contains(const std::string& magic_name, const xmagic_type type = xmagic_type::cell)
         {
-            if (type == xmagic_type::cell) 
+            if (type == xmagic_type::cell)
                 return m_magic_cell.find(magic_name) != m_magic_cell.end();
-            if (type == xmagic_type::line) 
+            if (type == xmagic_type::line)
                 return m_magic_line.find(magic_name) != m_magic_line.end();
         }
 
@@ -85,7 +87,7 @@ namespace xeus
             }
             try
             {
-                (*m_magic_cell[magic_name])(line, cell); 
+                (*m_magic_cell[magic_name])(line, cell);
             }
             catch (const cxxopts::OptionException& e)
             {
@@ -101,7 +103,7 @@ namespace xeus
         {
             try
             {
-                (*m_magic_line[magic_name])(line); 
+                (*m_magic_line[magic_name])(line);
             }
             catch (const cxxopts::OptionException& e)
             {
@@ -111,7 +113,7 @@ namespace xeus
             {
                 std::cerr << "Exception occurred. Recovering...\n";
             }
-        }        
+        }
 
         void apply(const std::string& code, xjson& kernel_res) override
         {
@@ -163,11 +165,12 @@ namespace xeus
         {
             return new xmagics_manager(*this);
         }
-        
+
     private:
+
         std::map<std::string, std::shared_ptr<xmagic_cell>> m_magic_cell;
         std::map<std::string, std::shared_ptr<xmagic_line>> m_magic_line;
-    };    
+    };
 }
 
 #endif

--- a/src/xoptions.cpp
+++ b/src/xoptions.cpp
@@ -17,17 +17,15 @@ namespace xeus
     {
         std::istringstream iss(line);
         std::vector<std::string> opt_strings((std::istream_iterator<std::string>(iss)),
-                                              std::istream_iterator<std::string>());
+                                             std::istream_iterator<std::string>());
 
         std::vector<char*> copt_strings;
 
-        for(std::size_t i = 0; i < opt_strings.size(); ++i)
+        for (std::size_t i = 0; i < opt_strings.size(); ++i)
             copt_strings.push_back(const_cast<char*>(opt_strings[i].c_str()));
-        
+
         int argc = copt_strings.size();
         auto argv = &copt_strings[0];
         parent::parse(argc, argv);
     }
-        
-
 }

--- a/src/xoptions.hpp
+++ b/src/xoptions.hpp
@@ -5,14 +5,15 @@
 *                                                                          *
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
-#ifndef XOPTIONS_HPP
-#define XOPTIONS_HPP
 
-#include <cxxopts.hpp>
+#ifndef XCPP_OPTIONS_HPP
+#define XCPP_OPTIONS_HPP
+
+#include "cxxopts.hpp"
 
 namespace xeus
 {
-    struct xoptions: public cxxopts::Options
+    struct xoptions : public cxxopts::Options
     {
         using parent = cxxopts::Options;
         using parent::Options;

--- a/src/xparser.cpp
+++ b/src/xparser.cpp
@@ -72,9 +72,9 @@ namespace xeus
                 {
                     result.push_back(lines[i] + "\n");
                     result.push_back("");
-                    rindex +=2;
+                    rindex += 2;
                 }
-                else 
+                else
                 {
                     if (std::regex_match(lines[i], incl_re))
                     {
@@ -112,8 +112,8 @@ namespace xeus
     bool short_has_arg(const std::string& opt, const std::string& short_opts)
     {
         auto n = short_opts.find(opt);
-        if ( n != std::string::npos )
-            return short_opts[n+1] == ':';
+        if (n != std::string::npos)
+            return short_opts[n + 1] == ':';
         // TODO raise an exception
         return false;
     }
@@ -122,11 +122,12 @@ namespace xeus
     {
         std::regex re_options("(?:\\-(\\w+)\\s*(\\w*)?|(?:\\-{2}(\\w+)\\s(\\w*)?))");
         std::map<std::string, std::string> map_opts;
-        
+
         auto opts_begin = std::sregex_iterator(input.begin(), input.end(), re_options);
         auto opts_end = std::sregex_iterator();
-        
-        for (std::sregex_iterator opt = opts_begin; opt != opts_end; ++opt) {
+
+        for (std::sregex_iterator opt = opts_begin; opt != opts_end; ++opt)
+        {
             std::smatch match = *opt;
             if (!match.str(1).empty())
             {
@@ -145,20 +146,20 @@ namespace xeus
 
     std::string trim(std::string const& str)
     {
-        if(str.empty())
+        if (str.empty())
             return str;
 
         std::size_t firstScan = str.find_first_not_of(' ');
-        std::size_t first     = firstScan == std::string::npos ? str.length() : firstScan;
-        std::size_t last      = str.find_last_not_of(' ');
-        return str.substr(first, last-first+1);
+        std::size_t first = firstScan == std::string::npos ? str.length() : firstScan;
+        std::size_t last = str.find_last_not_of(' ');
+        return str.substr(first, last - first + 1);
     }
 
     std::map<std::string, std::string> parse_opts(std::string& line, const std::string& opts)
     {
         auto map_opts = getopt(line, opts);
         // remove opts found in line
-        for (auto o: map_opts)
+        for (auto o : map_opts)
         {
             std::string tmp = "\\-" + o.first + "\\s*";
             if (!o.second.empty())
@@ -167,6 +168,4 @@ namespace xeus
         }
         return map_opts;
     }
-
-
 }

--- a/src/xparser.hpp
+++ b/src/xparser.hpp
@@ -5,8 +5,9 @@
 *                                                                          *
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
-#ifndef XPARSER_HPP
-#define XPARSER_HPP
+
+#ifndef XCPP_PARSER_HPP
+#define XCPP_PARSER_HPP
 
 #include <map>
 #include <string>
@@ -27,6 +28,5 @@ namespace xeus
     std::string trim(std::string const& str);
 
     std::map<std::string, std::string> parse_opts(std::string& line, const std::string& opts);
-
 }
 #endif

--- a/src/xpreamble.hpp
+++ b/src/xpreamble.hpp
@@ -5,12 +5,13 @@
 *                                                                          *
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
-#ifndef XPREAMBLE_HPP
-#define XPREAMBLE_HPP
 
-#include "xeus/xjson.hpp"
+#ifndef XCPP_PREAMBLE_HPP
+#define XCPP_PREAMBLE_HPP
 
 #include <regex>
+
+#include "xeus/xjson.hpp"
 
 namespace xeus
 {

--- a/src/xsystem.hpp
+++ b/src/xsystem.hpp
@@ -5,8 +5,9 @@
 *                                                                          *
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
-#ifndef XSYSTEM_HPP
-#define XSYSTEM_HPP
+
+#ifndef XCPP_SYSTEM_HPP
+#define XCPP_SYSTEM_HPP
 
 #include <cstdio>
 
@@ -14,7 +15,7 @@
 
 namespace xeus
 {
-    struct xsystem: xpreamble
+    struct xsystem : xpreamble
     {
         const std::string spattern = R"(^\!)";
         using xpreamble::pattern;
@@ -30,17 +31,29 @@ namespace xeus
             std::smatch to_execute;
             std::regex_search(code, to_execute, re);
 
-            int ret=1;
-    
-            // redirection of stderr in stdout
+            int ret = 1;
+
+            // Redirection of stderr to stdout
             std::string command = to_execute.str(1) + " 2>&1";
-            FILE *shell_result = popen(command.c_str(), "r");
-            if (shell_result) {
+
+#if defined(WIN32)
+            FILE* shell_result = _popen(command.c_str(), "r");
+#else
+            FILE* shell_result = popen(command.c_str(), "r");
+#endif
+            if (shell_result)
+            {
                 char buff[512];
                 ret = 0;
                 while (fgets(buff, sizeof(buff), shell_result))
-                std::cout << buff;
+                {
+                    std::cout << buff;
+                }
+#if defined(WIN32)
+                _pclose(shell_result);
+#else
                 pclose(shell_result);
+#endif
 
                 std::cout << std::flush;
                 kernel_res["status"] = "ok";
@@ -52,15 +65,14 @@ namespace xeus
                 kernel_res["status"] = "error";
                 kernel_res["ename"] = "ename";
                 kernel_res["evalue"] = "evalue";
-                kernel_res["traceback"] = {};            
+                kernel_res["traceback"] = {};
             }
         }
 
         virtual xpreamble* clone() const override
         {
-                return new xsystem(*this);
+            return new xsystem(*this);
         }
-
     };
 }
 #endif


### PR DESCRIPTION
- Add new xeus-cling logo to readme.
- Removing the C++17 kernel spec since not functional in our build.
- Adding a missing copyright statement and license terms
- I came across conflicts in inclusion guards when moving things to the xtl. So now, we will prefix library inclusion guards in all libraries. I propose XCPP for this one.
- Wrap `_popen / popen` with WIN32 guards.

