### PR TITLE
remove unused result parameter in metaprocessor

### DIFF
--- a/src/xcpp_interpreter.cpp
+++ b/src/xcpp_interpreter.cpp
@@ -33,13 +33,12 @@ namespace xeus
     void xcpp_interpreter::configure_impl()
     {
         // Process #include "xeus/xinterpreter.hpp" in a separate block.
-        cling::Value result;
         cling::Interpreter::CompilationResult compilation_result;
-        m_processor.process("#include \"xeus/xinterpreter.hpp\"", compilation_result, &result);
+        m_processor.process("#include \"xeus/xinterpreter.hpp\"", compilation_result);
 
         // Expose interpreter instance to cling
         std::string block = "xeus::register_interpreter(static_cast<xeus::xinterpreter*>((void*)" + std::to_string(intptr_t(this)) + "));";
-        m_processor.process(block.c_str(), compilation_result, &result);
+        m_processor.process(block.c_str(), compilation_result);
     }
 
     xcpp_interpreter::xcpp_interpreter(int argc, const char* const* argv)
@@ -66,7 +65,6 @@ namespace xeus
                                                  const xjson_node* user_expressions,
                                                  bool allow_stdin)
     {
-        cling::Value result;
         cling::Interpreter::CompilationResult compilation_result;
         xjson kernel_res;
 
@@ -87,7 +85,7 @@ namespace xeus
             auto errorlevel = 0;
             try
             {
-                errorlevel = m_processor.process(block.c_str(), compilation_result, &result);
+                errorlevel = m_processor.process(block.c_str(), compilation_result);
             }
             catch (cling::InterpreterException& e)
             {

--- a/src/xmagics/execution.cpp
+++ b/src/xmagics/execution.cpp
@@ -22,14 +22,13 @@ namespace xeus
 {
     timeit::timeit(cling::MetaProcessor* p):m_processor(p)
     {
-        cling::Value result;
         cling::Interpreter::CompilationResult compilation_result;
 
-        m_processor->process("#include <chrono>", compilation_result, &result);
+        m_processor->process("#include <chrono>", compilation_result);
 
         std::string init_timeit = "auto _t0 = std::chrono::high_resolution_clock::now();\n";
         init_timeit += "auto _t1 = std::chrono::high_resolution_clock::now();\n";           
-        m_processor->process(init_timeit.c_str(), compilation_result, &result);
+        m_processor->process(init_timeit.c_str(), compilation_result);
 
     }
 


### PR DESCRIPTION
This PR fixes the following code

```
std::vector<std::size_t> v{1, 2, 3, 4};
auto square = [](auto& e){e*=e;};
std::for_each(v.begin(), v.end(), square);
```

and cleanup the code of the unused parameter `result`.