### PR TITLE
Parser: Remove last newline

### DIFF
--- a/src/xparser.cpp
+++ b/src/xparser.cpp
@@ -106,6 +106,14 @@ namespace xeus
                 }
             }
         }
+
+        // Remove last new line for each block. Without this cling complains
+        // when a user gives .L file_path
+        for (auto &r : result) {
+            if (!r.empty() && r.back() == '\n') {
+                r.pop_back();
+            }
+        }
         return result;
     }
 

--- a/src/xparser.cpp
+++ b/src/xparser.cpp
@@ -60,6 +60,7 @@ namespace xeus
         // check if each line contains #include and concatenate the result in the good part of the result
         std::regex incl_re("\\#include.*");
         std::regex magic_re("^\\%\\w+");
+        std::regex dot_start_re("\\..*");
         std::vector<std::string> result;
         result.push_back("");
         std::size_t current = 0;  //0 include, 1 other
@@ -71,6 +72,11 @@ namespace xeus
                 if (std::regex_search(lines[i], magic_re))
                 {
                     result.push_back(lines[i] + "\n");
+                    result.push_back("");
+                    rindex += 2;
+                }
+                else if (std::regex_match(lines[i], dot_start_re)) {
+                    result.push_back(lines[i]);
                     result.push_back("");
                     rindex += 2;
                 }


### PR DESCRIPTION
With the current master the following code doesn't work.

```
.L /usr/local/libopencv_core.so
```

This raises:

```
input_line_7:1:10: warning: missing terminating '"' character
[-Winvalid-pp-token]
         ^
         input_line_7:1:10: error: expected "FILENAME" or <FILENAME>
         input_line_7:2:1: warning: missing terminating '"' character
         [-Winvalid-pp-token]
         "
         ^
         input_line_7:2:1: error: expected unqualified-id
```

Removing the last new line of input buffer does fixes the issue.