### PR TITLE
Distinguish execution result from print statement

### DIFF
--- a/src/xparser.cpp
+++ b/src/xparser.cpp
@@ -100,9 +100,13 @@ namespace xeus
                             rindex++;
                         }
                     }
-                    // if we have multiple lines, we add a semicolon at the end of the lines that not conatin
+                    // if we have multiple lines, we add a semicolon at the end of the lines that not contain
                     // #include keyword (except for the last line)
-                    result[rindex] += lines[i] + "\n";
+                    result[rindex] += lines[i];
+                    if (i != lines.size() - 1)
+                    {
+                        result[rindex] += "\n";
+                    }
                 }
             }
         }
@@ -113,7 +117,9 @@ namespace xeus
     {
         auto n = short_opts.find(opt);
         if (n != std::string::npos)
+        {
             return short_opts[n + 1] == ':';
+        }
         // TODO raise an exception
         return false;
     }
@@ -134,11 +140,15 @@ namespace xeus
                 if (short_has_arg(match.str(1), short_opts))
                 {
                     if (match.str(2).empty())
+                    {
                         std::cout << "Error: add exception !!!!\n";
+                    }
                     map_opts[match.str(1)] = match.str(2);
                 }
                 else
+                {
                     map_opts[match.str(1)] = "";
+                }
             }
         }
         return map_opts;
@@ -147,7 +157,9 @@ namespace xeus
     std::string trim(std::string const& str)
     {
         if (str.empty())
+        {
             return str;
+        }
 
         std::size_t firstScan = str.find_first_not_of(' ');
         std::size_t first = firstScan == std::string::npos ? str.length() : firstScan;
@@ -163,7 +175,9 @@ namespace xeus
         {
             std::string tmp = "\\-" + o.first + "\\s*";
             if (!o.second.empty())
+            {
                 tmp += o.second;
+            }
             line = std::regex_replace(line, std::regex(tmp), "");
         }
         return map_opts;


### PR DESCRIPTION
Fixes #67 

- [`MetaProcessor::process`](http://cling.web.cern.ch/cling/doxygen/classcling_1_1MetaProcessor.html#a75c5cf5c9c6dfb844dfe63b107799627) is now always called with `disableValuePrinting = true`.
- However, we want that information when it is the last statement and there is no semicolon.
  In this case, it can be retrieved from the optional `cling::Value`parameter of the same function.

This information is then passed to `publish_execution_result `.

In the following screenshot, you see the output prompts in the last two cells. I am not quite sure why `int i = 4` does not show anything.

<img width="577" alt="screen shot 2018-02-27 at 7 51 38 pm" src="https://user-images.githubusercontent.com/2397974/36748316-c7311a36-1bf7-11e8-8c6a-b3db9b2f49ee.png">

