### PR TITLE
Move to xcpp namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,8 +123,8 @@ endif("${isSystemDir}" STREQUAL "-1")
 set(XEUSCLING_SRC
     src/main.cpp
     src/xbuffer.hpp
-    src/xcpp_interpreter.cpp
-    src/xcpp_interpreter.hpp
+    src/xinterpreter.cpp
+    src/xinterpreter.hpp
     src/xdemangle.hpp
     src/xoptions.cpp
     src/xoptions.hpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "xcpp_interpreter.hpp"
+#include "xinterpreter.hpp"
 #include "xeus/xkernel.hpp"
 #include "xeus/xkernel_configuration.hpp"
 #include <iostream>
@@ -42,7 +42,7 @@ std::string get_stdopt(int argc, char** argv)
     return res;
 }
 
-using interpreter_ptr = std::unique_ptr<xeus::xcpp_interpreter>;
+using interpreter_ptr = std::unique_ptr<xcpp::interpreter>;
 interpreter_ptr build_interpreter(int argc, char** argv)
 {
     constexpr int interpreter_argc = 5;
@@ -54,7 +54,7 @@ interpreter_ptr build_interpreter(int argc, char** argv)
     interpreter_argv[2] = include_dir.c_str();
     interpreter_argv[3] = "";
     interpreter_argv[4] = "";
-    return interpreter_ptr(new xeus::xcpp_interpreter(interpreter_argc, interpreter_argv));
+    return interpreter_ptr(new xcpp::interpreter(interpreter_argc, interpreter_argv));
 }
 
 int main(int argc, char* argv[])

--- a/src/xbuffer.hpp
+++ b/src/xbuffer.hpp
@@ -14,7 +14,7 @@
 #include <streambuf>
 #include <string>
 
-namespace xeus
+namespace xcpp
 {
 
     class xbuffer : public std::streambuf
@@ -33,7 +33,7 @@ namespace xeus
 
         int overflow(int c) override
         {
-            this->sync();          
+            this->sync();
             using traits_type = std::streambuf::traits_type;
             if (!traits_type::eq_int_type(c, traits_type::eof()))
             {

--- a/src/xdemangle.hpp
+++ b/src/xdemangle.hpp
@@ -32,7 +32,7 @@
 #endif
 #endif
 
-namespace xeus
+namespace xcpp
 {
     const char* demangle(const char* name) noexcept;
     const char* demangle(const std::string& name) noexcept;

--- a/src/xholder_cling.cpp
+++ b/src/xholder_cling.cpp
@@ -3,7 +3,7 @@
 
 #include <algorithm>
 
-namespace xeus
+namespace xcpp
 {
 
     /***********************************
@@ -56,8 +56,7 @@ namespace xeus
         return *this;
     }
 
-
-    void xholder_preamble::apply(const std::string& s, xjson& kernel_res)
+    void xholder_preamble::apply(const std::string& s, xeus::xjson& kernel_res)
     {
         if (p_holder != nullptr)
         {

--- a/src/xholder_cling.hpp
+++ b/src/xholder_cling.hpp
@@ -14,7 +14,7 @@
 
 #include <regex>
 
-namespace xeus
+namespace xcpp
 {
     class xholder_preamble
     {
@@ -36,7 +36,7 @@ namespace xeus
             std::swap(p_holder, rhs.p_holder);
         }
 
-        void apply(const std::string& s, xjson& kernel_res);
+        void apply(const std::string& s, xeus::xjson& kernel_res);
         bool is_match(const std::string& s) const;
 
         template <class D>

--- a/src/xinspect.hpp
+++ b/src/xinspect.hpp
@@ -24,7 +24,7 @@
 #include "xparser.hpp"
 #include "xpreamble.hpp"
 
-namespace xeus
+namespace xcpp
 {
     struct node_predicate
     {
@@ -42,7 +42,6 @@ namespace xeus
         std::string class_name;
         std::string kind;
         std::string child_value;
-        std::string member_file;
 
         std::string get_filename(pugi::xml_node node)
         {
@@ -139,7 +138,7 @@ namespace xeus
         return typeString;
     }
 
-    void inspect(const std::string& code, xjson& kernel_res, cling::MetaProcessor& m_processor)
+    void inspect(const std::string& code, xeus::xjson& kernel_res, cling::MetaProcessor& m_processor)
     {
 
         std::string tagfile_dir = TAGFILE_DIR;
@@ -246,7 +245,7 @@ namespace xeus
                 width: 100%;
                 height: 100%;
             }
-            .xeus-iframe-pager {
+            .xcpp-iframe-pager {
                 padding: 0;
                 margin: 0;
                 width: 100%;
@@ -254,12 +253,12 @@ namespace xeus
                 border: none;
             }
             </style>
-            <iframe class="xeus-iframe-pager" src=")" +
+            <iframe class="xcpp-iframe-pager" src=")" +
                 inspect_result + R"("></iframe>)";
 
-            kernel_res["payload"] = xjson::array();
+            kernel_res["payload"] = xeus::xjson::array();
 
-            kernel_res["payload"][0] = xjson::object({
+            kernel_res["payload"][0] = xeus::xjson::object({
                 {"data", {{"text/plain", inspect_result}, {"text/html", html_content}}},
                 {"source", "page"},
                 {"start", 0}
@@ -284,7 +283,7 @@ namespace xeus
             pattern = spattern;
         }
 
-        void apply(const std::string& code, xjson& kernel_res) override
+        void apply(const std::string& code, xeus::xjson& kernel_res) override
         {
             std::regex re(spattern + R"((.*))");
             std::smatch to_inspect;

--- a/src/xinterpreter.hpp
+++ b/src/xinterpreter.hpp
@@ -23,15 +23,15 @@
 #include <string>
 #include <vector>
 
-namespace xeus
+namespace xcpp
 {
 
-    class xcpp_interpreter : public xinterpreter
+    class interpreter : public xeus::xinterpreter
     {
     public:
 
-        xcpp_interpreter(int argc, const char* const* argv);
-        virtual ~xcpp_interpreter();
+        interpreter(int argc, const char* const* argv);
+        virtual ~interpreter();
 
         void publish_stdout(const std::string&);
         void publish_stderr(const std::string&);
@@ -40,29 +40,29 @@ namespace xeus
 
         void configure_impl() override;
 
-        xjson execute_request_impl(int execution_counter,
-                                   const std::string& code,
-                                   bool silent,
-                                   bool store_history,
-                                   const xjson_node* user_expressions,
-                                   bool allow_stdin) override;
+        xeus::xjson execute_request_impl(int execution_counter,
+                                         const std::string& code,
+                                         bool silent,
+                                         bool store_history,
+                                         const xeus::xjson_node* user_expressions,
+                                         bool allow_stdin) override;
 
-        xjson complete_request_impl(const std::string& code,
-                                    int cursor_pos) override;
+        xeus::xjson complete_request_impl(const std::string& code,
+                                          int cursor_pos) override;
 
-        xjson inspect_request_impl(const std::string& code,
-                                   int cursor_pos,
-                                   int detail_level) override;
+        xeus::xjson inspect_request_impl(const std::string& code,
+                                         int cursor_pos,
+                                         int detail_level) override;
 
-        xjson history_request_impl(const xhistory_arguments& args) override;
+        xeus::xjson history_request_impl(const xeus::xhistory_arguments& args) override;
 
-        xjson is_complete_request_impl(const std::string& code) override;
+        xeus::xjson is_complete_request_impl(const std::string& code) override;
 
-        xjson kernel_info_request_impl() override;
+        xeus::xjson kernel_info_request_impl() override;
 
         void input_reply_impl(const std::string& value) override;
 
-        xjson get_error_reply(const std::string& ename,
+        xeus::xjson get_error_reply(const std::string& ename,
                               const std::string& evalue,
                               const std::vector<std::string>& trace_back);
 

--- a/src/xmagics.hpp
+++ b/src/xmagics.hpp
@@ -15,7 +15,7 @@
 #include "xoptions.hpp"
 #include "xpreamble.hpp"
 
-namespace xeus
+namespace xcpp
 {
     enum struct xmagic_type
     {

--- a/src/xmagics/execution.cpp
+++ b/src/xmagics/execution.cpp
@@ -4,7 +4,8 @@
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
 * The full license is in the file LICENSE, distributed with this software. *
-****************************************************************************/   
+****************************************************************************/
+
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -18,7 +19,7 @@
 #include "execution.hpp"
 #include "../xparser.hpp"
 
-namespace xeus
+namespace xcpp
 {
     timeit::timeit(cling::MetaProcessor* p):m_processor(p)
     {
@@ -27,7 +28,7 @@ namespace xeus
         m_processor->process("#include <chrono>", compilation_result);
 
         std::string init_timeit = "auto _t0 = std::chrono::high_resolution_clock::now();\n";
-        init_timeit += "auto _t1 = std::chrono::high_resolution_clock::now();\n";           
+        init_timeit += "auto _t1 = std::chrono::high_resolution_clock::now();\n";
         m_processor->process(init_timeit.c_str(), compilation_result);
 
     }
@@ -44,7 +45,6 @@ namespace xeus
              "without an option", cxxopts::value<std::vector<std::string>>());
         options.parse_positional("positional");
         return options;
-        
     }
 
     std::string timeit::inner(std::size_t number, std::string const & code) const

--- a/src/xmagics/execution.hpp
+++ b/src/xmagics/execution.hpp
@@ -5,6 +5,7 @@
 *                                                                          *
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
+
 #ifndef XMAGICS_EXECUTION_HPP
 #define XMAGICS_EXECUTION_HPP
 
@@ -15,7 +16,7 @@
 #include "../xmagics.hpp"
 #include "../xoptions.hpp"
 
-namespace xeus
+namespace xcpp
 {
     class timeit: public xmagic_line_cell
     {

--- a/src/xmagics/os.cpp
+++ b/src/xmagics/os.cpp
@@ -5,6 +5,7 @@
 *                                                                          *
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
+
 #include <iostream>
 #include <fstream>
 #include <string>
@@ -14,7 +15,7 @@
 #include "../xparser.hpp"
 #include "../xoptions.hpp"
 
-namespace xeus
+namespace xcpp
 {
     xoptions writefile::get_options()
     {
@@ -25,7 +26,7 @@ namespace xeus
         options.parse_positional("filename");
         return options;
     }
-    
+
     void writefile::operator()(const std::string& line, const std::string& cell)
     {
         auto options = get_options();
@@ -47,21 +48,21 @@ namespace xeus
             if (append)
             {
                 file.open(filename, std::ios::app);
-                std::cout << "Appending to " << filename << "\n"; 
+                std::cout << "Appending to " << filename << "\n";
             }
-            else 
+            else
             {
                 file.open(filename);
-                std::cout << "Overwriting " << filename << "\n"; 
+                std::cout << "Overwriting " << filename << "\n";
             }
         }
         else
         {
             file.open(filename);
-            std::cout << "Writing " << filename << "\n"; 
+            std::cout << "Writing " << filename << "\n";
         }
         file << cell << "\n";
-        file.close();        
+        file.close();
     }
 
     bool writefile::is_file_exist(const char* fileName)

--- a/src/xmagics/os.hpp
+++ b/src/xmagics/os.hpp
@@ -5,6 +5,7 @@
 *                                                                          *
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
+
 #ifndef XMAGICS_OS_HPP
 #define XMAGICS_OS_HPP
 
@@ -13,14 +14,17 @@
 #include "../xmagics.hpp"
 #include "../xoptions.hpp"
 
-namespace xeus
+namespace xcpp
 {
     class writefile: public xmagic_cell
     {
     public:
+
         xoptions get_options();
         virtual void operator()(const std::string& line, const std::string& cell) override;
+
     private:
+
         static bool is_file_exist(const char* fileName);
     };
 }

--- a/src/xmanager.hpp
+++ b/src/xmanager.hpp
@@ -13,7 +13,7 @@
 #include "xmagics.hpp"
 #include "xpreamble.hpp"
 
-namespace xeus
+namespace xcpp
 {
     struct xpreamble_manager
     {
@@ -121,7 +121,7 @@ namespace xeus
             }
         }
 
-        void apply(const std::string& code, xjson& kernel_res) override
+        void apply(const std::string& code, xeus::xjson& kernel_res) override
         {
             std::regex re_magic_cell(R"(^\%{2}(\w+))");
             std::smatch magic_name;

--- a/src/xoptions.cpp
+++ b/src/xoptions.cpp
@@ -5,24 +5,27 @@
 *                                                                          *
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
+
 #include <sstream>
 #include <string>
 #include <vector>
 
 #include "xoptions.hpp"
 
-namespace xeus
+namespace xcpp
 {
     void xoptions::parse(const std::string& line)
     {
         std::istringstream iss(line);
         std::vector<std::string> opt_strings((std::istream_iterator<std::string>(iss)),
-                                             std::istream_iterator<std::string>());
+                                              std::istream_iterator<std::string>());
 
         std::vector<char*> copt_strings;
 
         for (std::size_t i = 0; i < opt_strings.size(); ++i)
+        {
             copt_strings.push_back(const_cast<char*>(opt_strings[i].c_str()));
+        }
 
         int argc = copt_strings.size();
         auto argv = &copt_strings[0];

--- a/src/xoptions.hpp
+++ b/src/xoptions.hpp
@@ -11,7 +11,7 @@
 
 #include "cxxopts.hpp"
 
-namespace xeus
+namespace xcpp
 {
     struct xoptions : public cxxopts::Options
     {

--- a/src/xparser.cpp
+++ b/src/xparser.cpp
@@ -15,7 +15,7 @@
 
 #include "xparser.hpp"
 
-namespace xeus
+namespace xcpp
 {
     std::vector<std::string> split_line(const std::string& input, const std::string& delims, std::size_t cursor_pos)
     {

--- a/src/xparser.hpp
+++ b/src/xparser.hpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 
-namespace xeus
+namespace xcpp
 {
     std::vector<std::string> split_line(const std::string& input, const std::string& delims, std::size_t cursor_pos);
 

--- a/src/xpreamble.hpp
+++ b/src/xpreamble.hpp
@@ -13,7 +13,7 @@
 
 #include "xeus/xjson.hpp"
 
-namespace xeus
+namespace xcpp
 {
     struct xpreamble
     {
@@ -25,8 +25,9 @@ namespace xeus
             return std::regex_search(s, match, pattern);
         }
 
-        virtual void apply(const std::string& s, xjson& kernel_res) = 0;
+        virtual void apply(const std::string& s, xeus::xjson& kernel_res) = 0;
         virtual xpreamble* clone() const = 0;
+        virtual ~xpreamble() {};
     };
 }
 #endif

--- a/src/xsystem.hpp
+++ b/src/xsystem.hpp
@@ -13,7 +13,7 @@
 
 #include "xpreamble.hpp"
 
-namespace xeus
+namespace xcpp
 {
     struct xsystem : xpreamble
     {
@@ -25,7 +25,7 @@ namespace xeus
             pattern = spattern;
         }
 
-        void apply(const std::string& code, xjson& kernel_res) override
+        void apply(const std::string& code, xeus::xjson& kernel_res) override
         {
             std::regex re(spattern + R"((.*))");
             std::smatch to_execute;


### PR DESCRIPTION
- `xeus::xcpp_interpreter` -> `xcpp::interpreter`.
- remove unused attribute `class_member_predicate::member_file`.