### PR TITLE
Rich mime type rendering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,12 +150,23 @@ set(XEUSCLING_SRC
     src/xmagics/execution.hpp
     src/xmagics/os.cpp
     src/xmagics/os.hpp
+    src/xmime_internal.hpp
 )
+
+set(XCPP_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+set (XCPP_HEADERS
+   ${XCPP_INCLUDE_DIR}/xcpp/xmime.hpp
+   ${XCPP_INCLUDE_DIR}/xcpp/xdisplay.hpp
+)
+
 set(LLVM_NO_DEAD_STRIP 1)
 set(LIBS clingInterpreter clingMetaProcessor clingUtils xeus pugixml)
 set(XEUSCLING_TARGET xeus-cling)
 add_executable(${XEUSCLING_TARGET} ${XEUSCLING_SRC})
 set_target_properties(${XEUSCLING_TARGET} PROPERTIES ENABLE_EXPORTS 1)
+
+target_include_directories(${XEUSCLING_TARGET} PRIVATE ${XCPP_INCLUDE_DIR})
 
 if(MSVC)
     set_target_properties(${XEUSCLING_TARGET} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)  # Internal string
@@ -218,7 +229,7 @@ if(MSVC)
     foreach(sym ${cling_exports})
         set(cling_link_str "${cling_link_str} /EXPORT:${sym}")
     endforeach(sym ${cling_exports})
-    
+
     set_property(TARGET ${XEUSCLING_TARGET} APPEND_STRING PROPERTY LINK_FLAGS ${cling_link_str})
 endif(MSVC)
 
@@ -236,6 +247,9 @@ if(MSVC)
 else(MSVC)
     set(XEUS_KERNELSPEC_INSTALL_DIR "share/jupyter" CACHE STRING "install path for kernel specs")
 endif(MSVC)
+
+install(FILES ${XCPP_HEADERS}
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xcpp)
 
 set(KERNELSPEC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/kernels)
 install(DIRECTORY ${KERNELSPEC_DIR}

--- a/include/xcpp/xdisplay.hpp
+++ b/include/xcpp/xdisplay.hpp
@@ -1,0 +1,28 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Loic Gouarin and Sylvain Corlay       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XCPP_DISPLAY_HPP
+#define XCPP_DISPLAY_HPP
+
+#include "xmime.hpp"
+
+namespace xcpp
+{
+    template <class T>
+    void display(const T& t)
+    {
+        using ::xcpp::mime_bundle_repr;
+        xeus::get_interpreter().display_data(
+            mime_bundle_repr(&t),
+            xeus::xjson::object(),
+            xeus::xjson::object()
+        );
+    }
+}
+
+#endif

--- a/include/xcpp/xmime.hpp
+++ b/include/xcpp/xmime.hpp
@@ -1,0 +1,27 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Loic Gouarin and Sylvain Corlay       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XCPP_MIME_HPP
+#define XCPP_MIME_HPP
+
+#include "cling/Interpreter/RuntimePrintValue.h"
+#include "xeus/xjson.hpp"
+
+namespace xcpp
+{
+    // Default implementation of mime_bundle_repr
+    template <class T>
+    xeus::xjson mime_bundle_repr(const T* value)
+    {
+        auto bundle = xeus::xjson::object();
+        bundle["text/plain"] = cling::printValue(value);
+        return bundle;
+    }
+}
+
+#endif

--- a/notebooks/xcpp.ipynb
+++ b/notebooks/xcpp.ipynb
@@ -68,15 +68,13 @@
    "source": [
     "## Output and error streams\n",
     "\n",
-    "`std::cout` and `std::cerr` are correctly redirected"
+    "`std::cout` and `std::cerr` are redirected to the notebook frontend."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#include <iostream>\n",
@@ -87,9 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "std::cerr << \"some error\" << std::endl;"
@@ -98,9 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#include <stdexcept>"
@@ -109,9 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "throw std::runtime_error(\"BAAAD\");"
@@ -121,15 +113,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Omitting the `;` in the last statement of a cell gives an output"
+    "Omitting the `;` in the last statement of a cell results in an output being printed"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "int i = 4"
@@ -138,9 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "int j = 5;"
@@ -149,9 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "j"
@@ -176,9 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "double sqr(double a)\n",
@@ -190,9 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "double a = 2.5;\n",
@@ -210,9 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class Foo\n",
@@ -231,9 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "Foo bar;\n",
@@ -250,9 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class Bar : public Foo\n",
@@ -271,9 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "Foo* bar2 = new Bar;\n",
@@ -291,9 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#include <typeinfo>\n",
@@ -336,9 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "FooT<double> foot1(1.2);\n",
@@ -348,9 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "FooT<int> foot2(4);\n",
@@ -367,9 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class Foo11\n",
@@ -385,9 +351,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "Foo11 f1;\n",
@@ -398,9 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#include <vector>\n",
@@ -413,9 +375,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "*iter"
@@ -438,9 +398,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "?std::vector"
@@ -456,82 +414,51 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For a user-defined type `T`, implementing the function `xeus::xjson mime_bundle_repr(const T* im)` returning the json mime bundle representation for that type enables the rich rendering in the notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Image example"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#include <string>\n",
     "#include <fstream>\n",
     "\n",
-    "#include \"xtl/xbase64.hpp\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "std::ifstream fin(\"images/marie.png\", std::ios::binary);\n",
-    "std::stringstream buffer;\n",
-    "buffer << fin.rdbuf();"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "xeus::xjson mime;\n",
-    "mime[\"image/png\"] = xtl::base64encode(buffer.str());"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "xeus::get_interpreter().display_data(\n",
-    "    std::move(mime),\n",
-    "    xeus::xjson::object(),\n",
-    "    xeus::xjson::object());"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "std::ifstream fwav(\"audio/audio.wav\", std::ios::binary);\n",
-    "std::stringstream wav_buffer;\n",
-    "wav_buffer << fwav.rdbuf();\n",
-    "xeus::xjson audio_mime;"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "audio_mime[\"text/html\"] =\n",
-    "    std::string(\"<audio controls=\\\"controls\\\"><source src=\\\"data:audio/wav;base64,\")\n",
-    "    + xtl::base64encode(wav_buffer.str()) +\n",
-    "    \"\\\" type=\\\"audio/wav\\\" /></audio>\";"
+    "#include \"xtl/xbase64.hpp\"\n",
+    "#include \"xeus/xjson.hpp\"\n",
+    "\n",
+    "namespace im\n",
+    "{\n",
+    "    struct image\n",
+    "    {   \n",
+    "        inline image(const std::string& filename)\n",
+    "        {\n",
+    "            std::ifstream fin(filename, std::ios::binary);   \n",
+    "            m_buffer << fin.rdbuf();\n",
+    "        }\n",
+    "        \n",
+    "        std::stringstream m_buffer;\n",
+    "    };\n",
+    "    \n",
+    "    xeus::xjson mime_bundle_repr(const image* im)\n",
+    "    {\n",
+    "        auto bundle = xeus::xjson::object();\n",
+    "        bundle[\"image/png\"] = xtl::base64encode(im->m_buffer.str());\n",
+    "        return bundle;\n",
+    "    }\n",
+    "}"
    ]
   },
   {
@@ -540,10 +467,62 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xeus::get_interpreter().display_data(\n",
-    "    std::move(audio_mime),\n",
-    "    xeus::xjson::object(),\n",
-    "    xeus::xjson::object());"
+    "im::image marie(\"images/marie.png\");\n",
+    "marie"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Audio example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#include <string>\n",
+    "#include <fstream>\n",
+    "\n",
+    "#include \"xtl/xbase64.hpp\"\n",
+    "#include \"xeus/xjson.hpp\"\n",
+    "\n",
+    "namespace au\n",
+    "{\n",
+    "    struct audio\n",
+    "    {   \n",
+    "        inline audio(const std::string& filename)\n",
+    "        {\n",
+    "            std::ifstream fin(filename, std::ios::binary);   \n",
+    "            m_buffer << fin.rdbuf();\n",
+    "        }\n",
+    "        \n",
+    "        std::stringstream m_buffer;\n",
+    "    };\n",
+    "    \n",
+    "    xeus::xjson mime_bundle_repr(const audio* im)\n",
+    "    {\n",
+    "        auto bundle = xeus::xjson::object();\n",
+    "        bundle[\"text/html\"] =\n",
+    "           std::string(\"<audio controls=\\\"controls\\\"><source src=\\\"data:audio/wav;base64,\")\n",
+    "           + xtl::base64encode(im->m_buffer.str()) +\n",
+    "            \"\\\" type=\\\"audio/wav\\\" /></audio>\";\n",
+    "        return bundle;\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "au::audio drums(\"audio/audio.wav\");\n",
+    "drums"
    ]
   }
  ],

--- a/src/xholder_cling.cpp
+++ b/src/xholder_cling.cpp
@@ -1,3 +1,11 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Loic Gouarin and Sylvain Corlay       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
 #include "xholder_cling.hpp"
 #include "xpreamble.hpp"
 

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -12,18 +12,13 @@
 #include <sstream>
 #include <vector>
 
-#include "cling/Interpreter/Exception.h"
-#include "cling/Interpreter/Value.h"
-#include "cling/Utils/Output.h"
-
-#include "llvm/Support/raw_ostream.h"
-
 #include "xbuffer.hpp"
 #include "xinterpreter.hpp"
 #include "xinspect.hpp"
 #include "xmagics.hpp"
 #include "xmagics/execution.hpp"
 #include "xmagics/os.hpp"
+#include "xmime_internal.hpp"
 #include "xparser.hpp"
 #include "xsystem.hpp"
 
@@ -31,7 +26,6 @@ using namespace std::placeholders;
 
 namespace xcpp
 {
-
     void interpreter::configure_impl()
     {
         // Process #include "xeus/xinterpreter.hpp" in a separate block.
@@ -123,14 +117,7 @@ namespace xcpp
 
         if (output.hasValue() && trim(blocks.back()).back() != ';')
         {
-            std::string text_output;
-            {
-                llvm::raw_string_ostream output_stream(text_output);
-                output.print(output_stream, true);
-                output_stream.flush();
-            }
-            xeus::xjson pub_data;
-            pub_data["text/plain"] = std::move(text_output);
+            xeus::xjson pub_data = mime_repr(output);
             publish_execution_result(execution_counter, std::move(pub_data), xeus::xjson::object());
         }
 

--- a/src/xmime_internal.hpp
+++ b/src/xmime_internal.hpp
@@ -1,0 +1,213 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Loic Gouarin and Sylvain Corlay       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XCPP_MIME_INTERNAL_HPP
+#define XCPP_MIME_INTERNAL_HPP
+
+#include <cstddef>
+#include <locale>
+#include <string>
+
+#include "xeus/xjson.hpp"
+
+#include "cling/Interpreter/Exception.h"
+#include "cling/Interpreter/CValuePrinter.h"
+#include "cling/Interpreter/Interpreter.h"
+#include "cling/Interpreter/InterpreterCallbacks.h"
+#include "cling/Interpreter/LookupHelper.h"
+#include "cling/Interpreter/Transaction.h"
+#include "cling/Interpreter/Value.h"
+#include "cling/Utils/AST.h"
+#include "cling/Utils/Output.h"
+#include "cling/Utils/Validation.h"
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/Type.h"
+#include "clang/Frontend/CompilerInstance.h"
+
+#include "llvm/ExecutionEngine/GenericValue.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace xcpp
+{
+
+    /**************************************************************************
+    * The content of the cling_detail namespace is derived from cling which   *
+    * licensed under the UI/NCSAOSL license.                                  *
+    ***************************************************************************/
+
+    namespace cling_detail
+    {
+        struct LockCompilationDuringUserCodeExecutionRAII
+        {
+            /// Callbacks used to un/lock.
+            cling::InterpreterCallbacks* fCallbacks;
+
+            /// Info provided to UnlockCompilationDuringUserCodeExecution().
+            void* fStateInfo = nullptr;
+
+            LockCompilationDuringUserCodeExecutionRAII(cling::InterpreterCallbacks* callbacks)
+                : fCallbacks(callbacks)
+            {
+                if (fCallbacks)
+                {
+                    fStateInfo = fCallbacks->LockCompilationDuringUserCodeExecution();
+                }
+            }
+
+            LockCompilationDuringUserCodeExecutionRAII(cling::Interpreter& interp)
+                : LockCompilationDuringUserCodeExecutionRAII(interp.getCallbacks())
+            {
+            }
+
+            ~LockCompilationDuringUserCodeExecutionRAII()
+            {
+                if (fCallbacks)
+                {
+                    fCallbacks->UnlockCompilationDuringUserCodeExecution(fStateInfo);
+                }
+            }
+        };
+
+        struct AccessCtrlRAII_t
+        {
+            bool savedAccessControl;
+            clang::LangOptions& LangOpts;
+
+            AccessCtrlRAII_t(cling::Interpreter &Interp)
+              : LangOpts(const_cast<clang::LangOptions &>(Interp.getCI()->getLangOpts()))
+            {
+                savedAccessControl = LangOpts.AccessControl;
+                LangOpts.AccessControl = false;
+            }
+
+            ~AccessCtrlRAII_t()
+            {
+                LangOpts.AccessControl = savedAccessControl;
+            }
+        };
+
+        static std::string enclose(std::string Mid, const char* Begin, const char* End, std::size_t Hint = 0)
+        {
+            Mid.reserve(Mid.size() + Hint ? Hint : (::strlen(Begin) + ::strlen(End)));
+            Mid.insert(0, Begin);
+            Mid.append(End);
+            return Mid;
+        }
+
+        static std::string enclose(const clang::QualType &Ty, clang::ASTContext &C,
+                                   const char* Begin = "(", const char* End = "*)",
+                                   std::size_t Hint = 3)
+        {
+            return enclose(cling::utils::TypeName::GetFullyQualifiedName(Ty, C), Begin, End, Hint);
+        }
+
+        static clang::QualType getElementTypeAndExtent(const clang::ConstantArrayType* CArrTy, std::string& extent)
+        {
+            clang::QualType ElementTy = CArrTy->getElementType();
+            const llvm::APInt &APSize = CArrTy->getSize();
+            extent += '[' + std::to_string(APSize.getZExtValue()) + ']';
+            if (auto CArrElTy = llvm::dyn_cast<clang::ConstantArrayType>(ElementTy.getTypePtr()))
+            {
+                return getElementTypeAndExtent(CArrElTy, extent);
+            }
+            return ElementTy;
+        }
+
+        static std::string getTypeString(const cling::Value& V)
+        {
+            clang::ASTContext& C = V.getASTContext();
+            clang::QualType Ty = V.getType().getDesugaredType(C).getNonReferenceType();
+
+            if (llvm::dyn_cast<clang::BuiltinType>(Ty.getCanonicalType()))
+            {
+                return enclose(Ty, C);
+            }
+
+            if (Ty->isPointerType())
+            {
+                // Print char pointers as strings.
+                if (Ty->getPointeeType()->isCharType())
+                {
+                    return enclose(Ty, C);
+                }
+
+                // Fallback to void pointer for other pointers and print the address.
+                return "(const void**)";
+             }
+
+            if (Ty->isArrayType())
+            {
+                if (Ty->isConstantArrayType())
+                {
+                    std::string extent("(*)");
+                    clang::QualType InnermostElTy = getElementTypeAndExtent(C.getAsConstantArrayType(Ty), extent);
+                    return enclose(InnermostElTy, C, "(", (extent + ")*(void**)").c_str());
+                }
+                return "(void**)";
+            }
+            if (Ty->isObjCObjectPointerType())
+            {
+                return "(const void**)";
+            }
+
+            // In other cases, dereference the address of the object.
+            // If no overload or specific template matches,
+            // the general template will be used which only prints the address.
+            return enclose(Ty, C, "*(", "**)", 5);
+        }
+    }
+
+    inline xeus::xjson mime_repr(const cling::Value& V)
+    {
+        // Return a JSON mime bundle representing the specified value.
+
+        cling::Interpreter *interpreter = V.getInterpreter();
+        const void* value = V.getPtr();
+
+        // Include "xmime.hpp" only on the first time a variable is displayed.
+        static bool xmime_included = false;
+
+        if (!xmime_included)
+        {
+            cling_detail::LockCompilationDuringUserCodeExecutionRAII LCDUCER(*interpreter);
+            interpreter->declare("#include \"xcpp/xmime.hpp\"");
+            xmime_included = true;
+        }
+
+        cling::Value mimeReprV;
+        {
+            // Use an llvm::raw_ostream to prepend '0x' in front of the pointer value.
+            cling::ostrstream code;
+            code << "using xcpp::mime_bundle_repr;";
+            code << "mime_bundle_repr(";
+            code << xcpp::cling_detail::getTypeString(V);
+            code << &value;
+            code << ");";
+
+            cling_detail::AccessCtrlRAII_t AccessCtrlRAII(*interpreter);
+            cling_detail::LockCompilationDuringUserCodeExecutionRAII LCDUCER(*interpreter);
+            interpreter->process(code.str(), &mimeReprV);
+        }
+
+        if (mimeReprV.isValid() && mimeReprV.getPtr())
+        {
+            return *(xeus::xjson*)mimeReprV.getPtr();
+        }
+        else
+        {
+            return xeus::xjson::object();
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
To enable the rich rendering of complex types, just define `mime_bundle_repr` in the type's namespace. This uses ADL. Here are a few examples of rich types that are supported by the frontend.

## Image

<img width="549" alt="screen shot 2018-02-28 at 10 52 08 pm" src="https://user-images.githubusercontent.com/2397974/36815149-19fe5156-1cda-11e8-8f97-62332d80043b.png">

## Audio

<img width="544" alt="screen shot 2018-02-28 at 10 53 10 pm" src="https://user-images.githubusercontent.com/2397974/36815181-314846fa-1cda-11e8-862f-af4bb5615500.png">

## Widget

<img width="550" alt="screen shot 2018-02-28 at 10 54 48 pm" src="https://user-images.githubusercontent.com/2397974/36815255-70220848-1cda-11e8-94e4-39a40793f197.png">

The implementation in namespace `xw`is

```cpp

namespace xw
{
    template <template <class> class B, class... P>
    xeus::xjson mime_bundle_repr(const xmaterialize<B, P...>* val)
    {
        xeus::xjson mime_bundle;

        // application/vnd.jupyter.widget-view+json
        xeus::xjson widgets_json;
        widgets_json["version_major"] = XWIDGETS_PROTOCOL_VERSION_MAJOR;
        widgets_json["version_minor"] = XWIDGETS_PROTOCOL_VERSION_MINOR;
        widgets_json["model_id"] = val->id();
        mime_bundle["application/vnd.jupyter.widget-view+json"] = std::move(widgets_json);

        // text/plain
        mime_bundle["text/plain"] = "A Jupyter widget";
        return mime_bundle;
    }
}
```

## In progress:

- We need to add a `xcpp::display` which enables the display outside of the last statement.
- This duplicates a lot of logic from the internals of cling. Cleanup in progress.
- Requires adding a workaround to https://github.com/vgvassilev/cling/issues/176. Waiting on Vassil for the best option there.

cc @vgvassilev @carreau @jasongrout