### PR TITLE
Specify full path in kernel spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,9 @@ docs/build/
 # Build directory
 build/
 
+# generated kernel specs
+/kernels/xeus-cling-cpp11/kernel.json
+/kernels/xeus-cling-cpp14/kernel.json
+
 # Jupyter artefacts
 .ipynb_checkpoints/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,19 @@
 cmake_minimum_required(VERSION 3.4.3)
 project(xeus-cling)
 
+# Configuration
+# =============
+
+configure_file (
+    "${CMAKE_CURRENT_SOURCE_DIR}/kernels/xeus-cling-cpp11/kernel.json.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/kernels/xeus-cling-cpp11/kernel.json"
+)
+
+configure_file (
+    "${CMAKE_CURRENT_SOURCE_DIR}/kernels/xeus-cling-cpp14/kernel.json.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/kernels/xeus-cling-cpp14/kernel.json"
+)
+
 #######################
 # Rely on llvm-config #
 #######################

--- a/kernels/xeus-cling-cpp11/kernel.json.in
+++ b/kernels/xeus-cling-cpp11/kernel.json.in
@@ -1,7 +1,7 @@
 {
   "display_name": "xeus C++11",
   "argv": [
-      "xeus-cling",
+      "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/xeus-cling",
       "-f",
       "{connection_file}",
       "-std=c++11"

--- a/kernels/xeus-cling-cpp14/kernel.json.in
+++ b/kernels/xeus-cling-cpp14/kernel.json.in
@@ -1,7 +1,7 @@
 {
   "display_name": "xeus C++14",
   "argv": [
-      "xeus-cling",
+      "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/xeus-cling",
       "-f",
       "{connection_file}",
       "-std=c++14"


### PR DESCRIPTION
Solves the kernel executable path issue that @slel reported in 
https://github.com/sagemathinc/cocalc/issues/2324#issuecomment-363332376

This might be of interest for @minrk since you mentioned this in https://github.com/OpenDreamKit/OpenDreamKit/issues/96