### PR TITLE
Use macros for version strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,22 @@
 cmake_minimum_required(VERSION 3.4.3)
 project(xeus-cling)
 
+set(XCPP_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+# Versionning
+# ===========
+
+file(STRINGS "${XCPP_SRC_DIR}/xcpp_config.hpp" xcpp_version_defines
+     REGEX "#define XCPP_VERSION_(MAJOR|MINOR|PATCH)")
+foreach(ver ${xcpp_version_defines})
+    if(ver MATCHES "#define XCPP_VERSION_(MAJOR|MINOR|PATCH) +([^ ]+)$")
+        set(XCPP_VERSION_${CMAKE_MATCH_1} "${CMAKE_MATCH_2}" CACHE INTERNAL "")
+    endif()
+endforeach()
+set(${PROJECT_NAME}_VERSION
+    ${XCPP_VERSION_MAJOR}.${XCPP_VERSION_MINOR}.${XCPP_VERSION_PATCH})
+message(STATUS "Building xeus-cling v${${PROJECT_NAME}_VERSION}")
+
 # Configuration
 # =============
 
@@ -142,6 +158,7 @@ set(XEUSCLING_SRC
     src/xdemangle.hpp
     src/xoptions.cpp
     src/xoptions.hpp
+    src/xcpp_config.hpp
     src/xparser.cpp
     src/xparser.hpp
     src/xholder_cling.cpp

--- a/src/xcpp_config.hpp
+++ b/src/xcpp_config.hpp
@@ -1,0 +1,27 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Loic Gouarin and Sylvain Corlay       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XCPP_CONFIG_HPP
+#define XCPP_CONFIG_HPP
+
+// Project version
+#define XCPP_VERSION_MAJOR 0
+#define XCPP_VERSION_MINOR 2
+#define XCPP_VERSION_PATCH 1
+
+// Composing the version string from major, minor and patch
+#define XCPP_CONCATENATE(A, B) XCPP_CONCATENATE_IMPL(A, B)
+#define XCPP_CONCATENATE_IMPL(A, B) A##B
+#define XCPP_STRINGIFY(a) XCPP_STRINGIFY_IMPL(a)
+#define XCPP_STRINGIFY_IMPL(a) #a
+
+#define XCPP_VERSION XCPP_STRINGIFY(XCPP_CONCATENATE(XCPP_VERSION_MAJOR,   \
+                 XCPP_CONCATENATE(.,XCPP_CONCATENATE(XCPP_VERSION_MINOR,   \
+                                  XCPP_CONCATENATE(.,XCPP_VERSION_PATCH)))))
+
+#endif

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <vector>
 
+#include "xcpp_config.hpp"
 #include "xbuffer.hpp"
 #include "xinterpreter.hpp"
 #include "xinspect.hpp"
@@ -231,9 +232,8 @@ namespace xcpp
     xeus::xjson interpreter::kernel_info_request_impl()
     {
         xeus::xjson result;
-        result["protocol_version"] = "5.0.0";
         result["implementation"] = "xeus-cling";
-        result["implementation_version"] = "0.2.1";
+        result["implementation_version"] = XCPP_VERSION;
         result["language_info"]["name"] = "c++";
         result["language_info"]["version"] = m_version;
         result["language_info"]["mimetype"] = "text/x-c++src";


### PR DESCRIPTION
So that we have to change the versions in only one place, and we see the version being built.

Note: the `protocol_version` is set by xeus core to `5.1`. We should not set it in `xeus-cling`.