### PR TITLE
Adding C++17 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ build/
 # generated kernel specs
 /share/jupyter/kernels/xeus-cling-cpp11/kernel.json
 /share/jupyter/kernels/xeus-cling-cpp14/kernel.json
+/share/jupyter/kernels/xeus-cling-cpp17/kernel.json
 
 # Jupyter artefacts
 .ipynb_checkpoints/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ configure_file (
     "${CMAKE_CURRENT_SOURCE_DIR}/share/jupyter/kernels/xeus-cling-cpp14/kernel.json"
 )
 
+configure_file (
+    "${CMAKE_CURRENT_SOURCE_DIR}/share/jupyter/kernels/xeus-cling-cpp17/kernel.json.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/share/jupyter/kernels/xeus-cling-cpp17/kernel.json"
+)
+
 #######################
 # Rely on llvm-config #
 #######################

--- a/share/jupyter/kernels/xeus-cling-cpp17/kernel.json.in
+++ b/share/jupyter/kernels/xeus-cling-cpp17/kernel.json.in
@@ -1,0 +1,10 @@
+{
+  "display_name": "C++17",
+  "argv": [
+      "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/xeus-cling",
+      "-f",
+      "{connection_file}",
+      "-std=c++17"
+  ],
+  "language": "C++17"
+}


### PR DESCRIPTION
Not sure where / how to write a test case, but to verify create a C++17 notebook and execute the following cell:
```cpp
#include <tuple>
#include <iostream>

{
    auto [x, y] = std::pair<int, int>(10, 20);
    std::cout << x;
}
```
It should print "10" - cling seems to have some issues with C++17 syntax but the usual tricks of wrapping in braces or namespaces seem to work.