### PR TITLE
Fix type printing for new cling release

### DIFF
--- a/src/xmime_internal.hpp
+++ b/src/xmime_internal.hpp
@@ -108,10 +108,7 @@ namespace xcpp
                                    const char* Begin = "(", const char* End = "*)",
                                    std::size_t Hint = 3)
         {
-            clang::PrintingPolicy Policy(C.getPrintingPolicy());
-            Policy.PolishForDeclaration = true;
-            std::string name = Ty.getAsString(Policy);
-            return enclose(name, Begin, End, Hint);
+            return enclose(cling::utils::TypeName::GetFullyQualifiedName(Ty, C), Begin, End, Hint);
         }
 
         static clang::QualType getElementTypeAndExtent(const clang::ConstantArrayType* CArrTy, std::string& extent)


### PR DESCRIPTION
This requires `cling 0.5 build 7`,  which includes commit https://github.com/vgvassilev/cling/commit/4a226ee47aa5141545ef3488d8c500d58d9d9a61 as a patch, and makes @wolfv 's workaround unnecessary. 