### PR TITLE
Added the option to pass start up arguments for cling via environment variable.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,34 +29,17 @@ std::string get_filename(int argc, char* argv[])
     return res;
 }
 
-std::string get_stdopt(int argc, char** argv)
-{
-    std::string res = "-std=c++11";
-    for (int i = 0; i < argc; ++i)
-    {
-        std::string tmp(argv[i]);
-        if (tmp.find("-std=c++") != std::string::npos)
-        {
-            res = tmp;
-            argv[i] = (char*)"";
-            break;
-        }
-    }
-    return res;
-}
 
 using interpreter_ptr = std::unique_ptr<xcpp::interpreter>;
 interpreter_ptr build_interpreter(int argc, char** argv)
 {
-    int interpreter_argc = argc + 2;
+    int interpreter_argc = argc + 1;
     const char** interpreter_argv = new const char*[interpreter_argc];
     interpreter_argv[0] = "xeus-cling";
-    std::string stdopt = get_stdopt(argc, argv);
-    interpreter_argv[1] = stdopt.c_str();
     // Copy all arguments in the new array excepting the process name.
     for(int i = 1; i < argc; i++)
     {
-        interpreter_argv[i + 1] = argv[i];
+        interpreter_argv[i] = argv[i];
     }
     std::string include_dir = std::string(LLVM_DIR) + std::string("/include");
     interpreter_argv[interpreter_argc - 1] = include_dir.c_str();

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -40,7 +40,7 @@ namespace xcpp
 
     interpreter::interpreter(int argc, const char* const* argv)
         : m_cling(argc, argv, LLVM_DIR), m_processor(m_cling, cling::errs()),
-          m_version(std::string(argv[1]).substr(8)), // Extract C++ language standard version from command-line option
+          m_version(get_stdopt(argc, argv)), // Extract C++ language standard version from command-line option
           xmagics(),
           p_cout_strbuf(nullptr), p_cerr_strbuf(nullptr),
           m_cout_buffer(std::bind(&interpreter::publish_stdout, this, _1)),
@@ -331,5 +331,20 @@ namespace xcpp
     {
         preamble_manager["magics"].get_cast<xmagics_manager>().register_magic("file", writefile());
         preamble_manager["magics"].get_cast<xmagics_manager>().register_magic("timeit", timeit(&m_processor));
+    }
+
+    std::string interpreter::get_stdopt(int argc, const char* const* argv)
+    {
+        std::string res = "-std=c++11";
+        for (int i = 0; i < argc; ++i)
+        {
+            std::string tmp(argv[i]);
+            if (tmp.find("-std=c++") != std::string::npos)
+            {
+                res = tmp;
+                break;
+            }
+        }
+        return res;
     }
 }

--- a/src/xinterpreter.hpp
+++ b/src/xinterpreter.hpp
@@ -72,6 +72,8 @@ namespace xcpp
         void init_preamble();
         void init_magic();
 
+        std::string get_stdopt(int argc, const char* const* argv);
+
         cling::Interpreter m_cling;
         cling::MetaProcessor m_processor;
         std::string m_version;


### PR DESCRIPTION
I add a function to pass start up arguments to cling via CLING_OPTS environment variable. It's the same solution like in the cling jupyter kernel https://github.com/root-project/cling/commit/6bbf1f331185ce9b6c0bfe236e687e62112ad747

example:
```json
{
  "display_name": "myCustomKernel",
  "argv": [
      "/opt/xeus-cling/bin/xeus-cling",
      "-f",
      "{connection_file}",
      "-std=c++11"
  ],
  "language": "C++11",
  "env": {"CLING_OPTS": "-fopenmp -Wall -I<add_directory_to_include_search_path> -L<add_directory_to_library_search_path>"}
}
```

Unfortunately, I found no documentation about how to prepare a pull request for your project. Could you please tell me, what I have to do, to finish the pull request for a merge.

Additionally, I have a question. Why 5 arguments, where the last 2 are empty, have to pass to the interpreter instance? 3 Arguments plus the arguments of the CLING_OPTS variable should be enough.