### PR TITLE
bump xtensor versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - xeus-cling=0.5.1
-  - xtensor=0.20.4
-  - xtensor-blas=0.16.0
+  - xtensor=0.20.8
+  - xtensor-blas=0.16.1
   - notebook


### PR DESCRIPTION
seems to fix issues creating the environment which pin a pulled version of xeus (0.19.3)