### PR TITLE
CMake: Build Type Overwriteable

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,9 @@ image:
   - Visual Studio 2017
   - Visual Studio 2015
 
+configuration:
+  - Release
+
 environment:
   matrix:
     - MINICONDA: C:\xeus-conda
@@ -33,7 +36,7 @@ install:
   # Build and install xeus-cling
   - mkdir build
   - cd build
-  - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\Library -D XEXTRA_JUPYTER_DATA_DIR=%MINICONDA%\\share\\jupyter ..
+  - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\Library -D CMAKE_BUILD_TYPE=%CONFIGURATION% -D XEXTRA_JUPYTER_DATA_DIR=%MINICONDA%\\share\\jupyter ..
   - nmake
   - nmake install
   # Install jupyter_kernel_test and pytest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,10 @@ find_package(cxxopts REQUIRED)
 
 include(CheckCXXCompilerFlag)
 
-set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+        "Choose the build type, e.g. Release or Debug." FORCE)
+endif()
 
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4251 /wd4141")


### PR DESCRIPTION
It's ok to make the default build type "Release", but it should stay controllable from the outside :)

cc @SimeonEhrig 