### PR TITLE
Fix incorrect comment in demo notebook

### DIFF
--- a/notebooks/xcpp.ipynb
+++ b/notebooks/xcpp.ipynb
@@ -552,7 +552,7 @@
     "    }\n",
     "}\n",
     "\n",
-    "// A red rectangle\n",
+    "// A blue rectangle\n",
     "ht::html rect(R\"(\n",
     "<div style='\n",
     "    width: 90px;\n",
@@ -580,7 +580,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "// Update the rectangle to be blue\n",
+    "// Update the rectangle to be red\n",
     "rect.m_content = R\"(\n",
     "<div style='\n",
     "    width: 90px;\n",


### PR DESCRIPTION
The rectangle is first blue and is then updated to be red.