### PR TITLE
Added Nix build files

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,53 @@
+{ pkgs ? import <nixpkgs> {}
+, useLLVMLibcxx ? false
+, ... }:
+
+with pkgs;
+
+pkgs.llvmPackages.stdenv.mkDerivation rec {
+  name = "xeus-cling";
+  src = ./.;
+
+  nativeBuildInputs = with pkgs; [
+    cmake
+    makeWrapper
+  ];
+
+  buildInputs = with pkgs; [
+    xeus
+    xeus-zmq
+    cppzmq
+    cling.unwrapped
+    argparse
+    xtl
+    pugixml
+    nlohmann_json
+    openssl
+    llvmPackages_9.libllvm
+    llvmPackages_9.libclang
+    libuuid
+  ];
+
+  # Runtime flags for the C++ standard library
+  cxxFlags = if useLLVMLibcxx then [
+    "-I" "${lib.getDev llvmPackages_9.libcxx}/include/c++/v1"
+    "-L" "${llvmPackages_9.libcxx}/lib"
+    "-l" "${llvmPackages_9.libcxx}/lib/libc++.so"
+  ] else [
+    "-I" "${gcc-unwrapped}/include/c++/${gcc-unwrapped.version}"
+    "-I" "${gcc-unwrapped}/include/c++/${gcc-unwrapped.version}/x86_64-unknown-linux-gnu"
+  ];
+
+  flags = [
+    "-nostdinc"
+    "-nostdinc++"
+    "-isystem" "${cling.unwrapped}/lib/clang/9.0.1/include"
+  ] ++ cxxFlags ++ [
+    "-isystem" "${lib.getDev stdenv.cc.libc}/include"
+    "-isystem" "${cling.unwrapped}/include"
+  ];
+
+  fixupPhase = ''
+    wrapProgram $out/bin/xcpp --add-flags "$flags"
+  '';
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1695628505,
+        "narHash": "sha256-gkn36kbqNQgKEs7RM7MSVQh84VIwmM9fvFCffC70mq8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "29351a88df4201a8423fb4ab72b9438251e6744e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,9 @@
+{ description = "xeus-cling Jupyter kernel";
+
+  inputs."nixpkgs".url = github:NixOS/nixpkgs;
+
+  outputs = { self, nixpkgs, ... }:
+  { packages.x86_64-linux.default =
+      (import nixpkgs { system="x86_64-linux"; }).callPackage ./default.nix {};
+  };
+}


### PR DESCRIPTION
This PR proposal adds build files for the [Nix package manager](https://nixos.org), effectively turning this project into a "Nix Flake". The rationale is that C/C++ projects usually induce a lot of interference with the local build environment, which the Nix package manager alleviates.

These files let Nix build `xeus-cling` with all required dependencies, allowing one to install the kernel with a single command: `nix profile install github:jupyter-xeus/xeus-cling`, and copying/linking the kernel definition files in `~/.nix-profile/share/jupyter/kernels` into `~/.local/share/jupyter/kernels`.

(another approach for installing kernel defs would be a tiny script like `xcpp-install` that writes kernel defs in the user's Jupyter data directory.)

As long as `flake.lock` is committed, all dependencies are pinned to a strict version from the upstream NixOS project. Not committing it will let dependencies update automatically, but this may make builds less reliable.

This also provides another way to create a dev environment for working on `xeus-cling`: running `nix develop`, which opens a shell with the build environment Nix itself would use to build a release of `xeus-cling`.

This change does not interfere with the rest of the project.