### PR TITLE
Fix images in installation instructions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,15 @@ git clone https://github.com/<your-github-username>/xeus-cling.git
 
 You may also want to install a C++ compiler, and cmake from conda if they are not available on your system.
 
+### Contributing to the documentation
+
+You don't need to build and install the package to build the documentation.
+[Sphinx](https://www.sphinx-doc.org) is used to generate it and should be installed in your
+development environment or system.
+
+The documentation sources are in `docs/sources/` and uses [ReStructured Text](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html).
+When done with your modifications you can render them with
+```bash
+cd docs
+make html
+```

--- a/docs/source/_static/main_stylesheet.css
+++ b/docs/source/_static/main_stylesheet.css
@@ -2,3 +2,13 @@
     max-width: 1000px;
     margin: auto;
 }
+
+.rst-content h2 > img {
+    width: 30px;
+    margin-bottom: 0;
+    margin-top: 0;
+    margin-right: 15px;
+    margin-left: 15px;
+    float: left;
+}
+

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,26 +4,16 @@
 
    The full license is in the file LICENSE, distributed with this software.
 
-.. raw:: html
+.. |conda| image:: conda.svg
 
-   <style>
-   .rst-content .section>img {
-       width: 30px;
-       margin-bottom: 0;
-       margin-top: 0;
-       margin-right: 15px;
-       margin-left: 15px;
-       float: left;
-   }
-   </style>
+.. |cmake| image:: cmake.svg
+
 
 Installation
 ============
 
-.. image:: conda.svg
-
-Using the conda-forge package
-------------------------------
+|conda| Using the conda-forge package
+-------------------------------------
 
 A package for xeus-cling is available for the mamba (or conda) package manager.
 
@@ -31,10 +21,8 @@ A package for xeus-cling is available for the mamba (or conda) package manager.
 
     mamba install -c conda-forge xeus-cling
 
-.. image:: cmake.svg
-
-From source with cmake
-----------------------
+|cmake| From source with cmake
+------------------------------
 
 You can also install ``xeus-cling`` from source with cmake. This requires that you have all the dependencies installed in the same prefix.
 


### PR DESCRIPTION
Dear maintainers,

this pull request fixes the display of the anaconda and cmake logos in the installation instructions ... probably a nitpick but I found the [big logos](https://xeus-cling.readthedocs.io/en/latest/installation.html) a bit annoying for the scrolling... bear with me.

In the meanwhile I've added some details about how to contribute to the documentation in `CONTRIBUTING.md` .

Thanks for considering this contribution.